### PR TITLE
make the library compiling again

### DIFF
--- a/request_context.go
+++ b/request_context.go
@@ -86,7 +86,7 @@ func (l Logger) Error(ctx Ctx, f string, v ...interface{}) {
 		return
 	}
 
-	l.logger.Error(l.extendFormat(ctx, f), v...)
+	l.logger.Errorf(l.extendFormat(ctx, f), v...)
 }
 
 func (l Logger) Warning(ctx Ctx, f string, v ...interface{}) {


### PR DESCRIPTION
Because if changes here https://github.com/op/go-logging/commit/0758a840b4a169597e34fe01fde5d13ffb31aa68 this needs to be fixed. The change in the dependency repository makes no sense to me. Anyway, I don't care. Just want to make it work right now. 

RFR @JosephSalisbury 
