### PR TITLE
Pin go-logging to commit before backwards compatability is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ get-deps: .gobuild
 .gobuild:
 	mkdir -p $(GS_PATH)
 	cd "$(GS_PATH)" && ln -s ../../../.. $(PROJECT)
+	
+	# Pin versions of certain libs
+	@builder get dep -b b2cb9fa56473e98db8caba80237377e83fe44db5 https://github.com/op/go-logging.git $(GOPATH)/src/github.com/op/go-logging
 
 	#
 	# Fetch public dependencies via `go get`


### PR DESCRIPTION
```
$ make clean && make
rm -rf /Users/joseph/Repos/request-context/.gobuild request-context
mkdir -p "/Users/joseph/Repos/request-context/.gobuild/src/github.com/giantswarm"
cd ""/Users/joseph/Repos/request-context/.gobuild/src/github.com/giantswarm"" && ln -s ../../../.. request-context
# Pin versions of certain libs
Found version v1, wanted b2cb9fa56473e98db8caba80237377e83fe44db5. Updating .gobuild/src/github.com/op/go-logging now.
Update available for .gobuild/src/github.com/op/go-logging: 'b2cb9fa56473e98db8caba80237377e83fe44db5' => 'v1'
#
# Fetch public dependencies via `go get`
GOPATH=/Users/joseph/Repos/request-context/.gobuild go get -d -v github.com/giantswarm/request-context
github.com/juju/errgo (download)
GOPATH=/Users/joseph/Repos/request-context/.gobuild go build -o request-context
```
